### PR TITLE
Add tagged data cache revalidation

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -26,9 +26,11 @@ jobs:
           fi
 
           curl --silent --show-error --fail-with-body \
+            --location \
+            --max-redirs 0 \
             --retry 12 \
             --retry-delay 10 \
             --retry-all-errors \
             --request POST \
             --header "Authorization: Bearer ${REVALIDATE_SECRET}" \
-            https://1700chess.sh/api/revalidate
+            https://www.1700chess.sh/api/revalidate

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -16,3 +16,19 @@ jobs:
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - name: Revalidate frontend data cache
+        env:
+          REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
+        run: |
+          if [ -z "${REVALIDATE_SECRET}" ]; then
+            echo "REVALIDATE_SECRET is not configured; skipping frontend revalidation."
+            exit 0
+          fi
+
+          curl --silent --show-error --fail-with-body \
+            --retry 12 \
+            --retry-delay 10 \
+            --retry-all-errors \
+            --request POST \
+            --header "Authorization: Bearer ${REVALIDATE_SECRET}" \
+            https://1700chess.sh/api/revalidate

--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ npm run dev  # serves on http://localhost:3000
 NEXT_PUBLIC_API_URL=http://127.0.0.1:5004/api
 ```
 
+### Results cache revalidation
+
+Public API fetches are cached in the Next.js Data Cache for up to one day and
+share the `gp-data` cache tag. The frontend remains dynamically rendered, so
+site-code deployments are not held behind the data cache.
+
+Set the same strong `REVALIDATE_SECRET` value in:
+
+- Vercel, for the protected `/api/revalidate` route.
+- GitHub Actions, so a successful Fly deployment invalidates cached results.
+- Fly, so production admin edits can invalidate cached results immediately.
+
+Fly can optionally set `FRONTEND_REVALIDATE_URL` when the frontend revalidation
+endpoint is not `https://1700chess.sh/api/revalidate`. If a webhook is missed,
+the one-day cache lifetime provides automatic recovery.
+
 ### Font references
 
 - Maple Mono official download: https://font.subf.dev/en/download/

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Set the same strong `REVALIDATE_SECRET` value in:
 - Fly, so production admin edits can invalidate cached results immediately.
 
 Fly can optionally set `FRONTEND_REVALIDATE_URL` when the frontend revalidation
-endpoint is not `https://1700chess.sh/api/revalidate`. If a webhook is missed,
+endpoint is not `https://www.1700chess.sh/api/revalidate`. If a webhook is missed,
 the one-day cache lifetime provides automatic recovery.
 
 ### Font references

--- a/app.py
+++ b/app.py
@@ -36,7 +36,7 @@ SLOW_REQUEST_MS = int(os.environ.get("SLOW_REQUEST_MS", "1000"))
 ADMIN_DEBUG_LOGIN = os.environ.get("ADMIN_DEBUG_LOGIN", "false").lower() == "true"
 FRONTEND_REVALIDATE_URL = os.environ.get(
     "FRONTEND_REVALIDATE_URL",
-    "https://1700chess.sh/api/revalidate",
+    "https://www.1700chess.sh/api/revalidate",
 )
 REVALIDATE_SECRET = os.environ.get("REVALIDATE_SECRET", "")
 
@@ -60,7 +60,13 @@ def _revalidate_frontend_data() -> bool:
             FRONTEND_REVALIDATE_URL,
             headers={"Authorization": f"Bearer {REVALIDATE_SECRET}"},
             timeout=5,
+            allow_redirects=False,
         )
+        if response.is_redirect:
+            raise http_requests.TooManyRedirects(
+                f"Frontend revalidation unexpectedly redirected to {response.headers.get('Location', 'unknown')}",
+                response=response,
+            )
         response.raise_for_status()
         logger.info("frontend_revalidation_succeeded")
         return True

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ import io
 import time
 import hmac
 import hashlib
+import requests as http_requests
 from functools import wraps
 from pathlib import Path
 from flask import Response
@@ -33,6 +34,11 @@ REQUEST_LOGGING_ENABLED = os.environ.get("REQUEST_LOGGING_ENABLED", "true").lowe
 REQUEST_IP_LOGGING_ENABLED = os.environ.get("REQUEST_IP_LOGGING_ENABLED", "true").lower() == "true"
 SLOW_REQUEST_MS = int(os.environ.get("SLOW_REQUEST_MS", "1000"))
 ADMIN_DEBUG_LOGIN = os.environ.get("ADMIN_DEBUG_LOGIN", "false").lower() == "true"
+FRONTEND_REVALIDATE_URL = os.environ.get(
+    "FRONTEND_REVALIDATE_URL",
+    "https://1700chess.sh/api/revalidate",
+)
+REVALIDATE_SECRET = os.environ.get("REVALIDATE_SECRET", "")
 
 
 def _get_client_ip() -> str:
@@ -41,6 +47,29 @@ def _get_client_ip() -> str:
     if x_forwarded_for:
         return x_forwarded_for.split(",")[0].strip()
     return request.headers.get("CF-Connecting-IP") or request.remote_addr or "unknown"
+
+
+def _revalidate_frontend_data() -> bool:
+    """Best-effort invalidation of the frontend's cached public API data."""
+    if not REVALIDATE_SECRET:
+        logger.info("frontend_revalidation_skipped secret_not_configured")
+        return False
+
+    try:
+        response = http_requests.post(
+            FRONTEND_REVALIDATE_URL,
+            headers={"Authorization": f"Bearer {REVALIDATE_SECRET}"},
+            timeout=5,
+        )
+        response.raise_for_status()
+        logger.info("frontend_revalidation_succeeded")
+        return True
+    except http_requests.RequestException:
+        # Database writes have already succeeded. Do not turn a temporary
+        # frontend/network problem into a failed admin mutation response; the
+        # one-day Next cache TTL remains the fallback.
+        logger.exception("frontend_revalidation_failed")
+        return False
 
 
 @app.before_request
@@ -70,12 +99,15 @@ def add_cache_headers(response):
         else:
             logger.info("request %s", log_payload)
 
-    """Add cache headers to GET requests (skip admin routes)."""
+    """Require HTTP clients to revalidate public API responses before reuse."""
     if request.method == 'GET' and response.status_code == 200 and not request.path.startswith('/api/admin'):
         if app.debug:
             response.headers['Cache-Control'] = 'no-store'
         else:
-            response.headers['Cache-Control'] = 'public, max-age=86400'
+            # Next's tagged Data Cache is the single cache owner. Keeping the
+            # origin revalidatable prevents an intermediary from returning old
+            # results after Next has invalidated its own cache.
+            response.headers['Cache-Control'] = 'no-cache, must-revalidate'
     return response
 
 
@@ -1333,6 +1365,7 @@ def admin_scrape_commit():
             source_id=tournament_id,
         )
         db.recalculate_rankings()
+        _revalidate_frontend_data()
         return jsonify({"ok": True, "tournament_id": db_tournament_id})
     except Exception as e:
         logger.error(f"Error committing scrape for {tournament_id}: {e}")
@@ -1360,6 +1393,7 @@ def admin_update_tournament(tournament_id):
     body = request.get_json(silent=True) or {}
     updated = db.update_tournament_metadata(tournament_id, **body)
     if updated:
+        _revalidate_frontend_data()
         return jsonify({"ok": True})
     return jsonify({"error": "Tournament not found or no changes"}), 404
 
@@ -1369,6 +1403,7 @@ def admin_update_tournament(tournament_id):
 def admin_delete_tournament(tournament_id):
     db.delete_tournament_data(tournament_id)
     db.recalculate_rankings()
+    _revalidate_frontend_data()
     return jsonify({"ok": True})
 
 
@@ -1379,6 +1414,7 @@ def admin_update_result(tournament_id, fide_id):
     updated = db.update_result(tournament_id, fide_id, **body)
     if updated:
         db.recalculate_rankings()
+        _revalidate_frontend_data()
         return jsonify({"ok": True})
     return jsonify({"error": "Result not found"}), 404
 
@@ -1389,6 +1425,7 @@ def admin_delete_result(tournament_id, fide_id):
     deleted = db.delete_result(tournament_id, fide_id)
     if deleted:
         db.recalculate_rankings()
+        _revalidate_frontend_data()
         return jsonify({"ok": True})
     return jsonify({"error": "Result not found"}), 404
 

--- a/client/app/api/revalidate/route.ts
+++ b/client/app/api/revalidate/route.ts
@@ -1,0 +1,35 @@
+import { timingSafeEqual } from 'node:crypto'
+import { revalidateTag } from 'next/cache'
+import type { NextRequest } from 'next/server'
+import { GP_DATA_CACHE_TAG } from '@/lib/data-cache'
+
+function secretsMatch(received: string | null, expected: string): boolean {
+  if (!received) return false
+
+  const receivedBuffer = Buffer.from(received)
+  const expectedBuffer = Buffer.from(`Bearer ${expected}`)
+
+  return (
+    receivedBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(receivedBuffer, expectedBuffer)
+  )
+}
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.REVALIDATE_SECRET
+
+  if (!secret) {
+    console.error('REVALIDATE_SECRET is not configured')
+    return Response.json({ error: 'Revalidation is not configured' }, { status: 503 })
+  }
+
+  if (!secretsMatch(request.headers.get('authorization'), secret)) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // expire: 0 makes the next request wait for fresh data instead of serving one
+  // stale response while the cache refreshes in the background.
+  revalidateTag(GP_DATA_CACHE_TAG, { expire: 0 })
+
+  return Response.json({ revalidated: true, tag: GP_DATA_CACHE_TAG })
+}

--- a/client/app/insights/page.tsx
+++ b/client/app/insights/page.tsx
@@ -6,7 +6,8 @@ import {
   Trophy, Dumbbell, Scale, Clock, AlertTriangle, Activity, Crosshair
 } from 'lucide-react'
 
-export const dynamic = 'force-dynamic'
+// Render HTML per request while allowing explicitly cached data fetches.
+export const revalidate = 0
 
 export const metadata: Metadata = {
   title: 'Season Insights - Chess Kenya Grand Prix',

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -9,7 +9,8 @@ import { getSeasons } from '@/services/api'
 import { TrackedLink } from '@/components/tracked-link'
 import { ArrowRight } from 'lucide-react'
 
-export const dynamic = 'force-dynamic'
+// Render HTML per request while allowing explicitly cached data fetches.
+export const revalidate = 0
 
 export const metadata: Metadata = {
   title: 'Chess Kenya Grand Prix - Official Tournament Tracker',

--- a/client/app/player/[id]/page.tsx
+++ b/client/app/player/[id]/page.tsx
@@ -3,7 +3,8 @@ import Link from 'next/link'
 import PlayerClientContent from './player-client-content'
 import { Metadata } from 'next'
 
-export const dynamic = 'force-dynamic'
+// Render HTML per request while allowing explicitly cached data fetches.
+export const revalidate = 0
 
 interface PlayerPageProps {
   params: { id: string }

--- a/client/app/rankings/page.tsx
+++ b/client/app/rankings/page.tsx
@@ -37,7 +37,8 @@ export const metadata: Metadata = {
   }
 }
 
-export const dynamic = 'force-dynamic'
+// Render HTML per request while allowing explicitly cached data fetches.
+export const revalidate = 0
 
 // Smart name abbreviation function for very long names
 function getDisplayName(fullName: string): string {

--- a/client/app/sitemap.ts
+++ b/client/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from 'next'
 import { getTournaments } from '@/services/api'
 
-export const dynamic = 'force-dynamic'
+export const revalidate = 86400
 
 const BASE_URL = 'https://1700chess.sh'
 

--- a/client/app/tournament/[id]/page.tsx
+++ b/client/app/tournament/[id]/page.tsx
@@ -20,7 +20,8 @@ import { TrackedLink } from '@/components/tracked-link'
 import { SectionSelector } from '@/components/tournament/section-selector'
 import { Metadata } from 'next'
 
-export const dynamic = 'force-dynamic'
+// Render HTML per request while allowing explicitly cached data fetches.
+export const revalidate = 0
 
 interface TournamentPageProps {
   params: {

--- a/client/lib/data-cache.ts
+++ b/client/lib/data-cache.ts
@@ -1,0 +1,10 @@
+export const GP_DATA_CACHE_TAG = 'gp-data'
+export const GP_DATA_REVALIDATE_SECONDS = 86400
+
+export const GP_DATA_CACHE: RequestInit = {
+  cache: 'force-cache',
+  next: {
+    revalidate: GP_DATA_REVALIDATE_SECONDS,
+    tags: [GP_DATA_CACHE_TAG]
+  }
+}

--- a/client/services/api.ts
+++ b/client/services/api.ts
@@ -1,7 +1,11 @@
+import { GP_DATA_CACHE } from '@/lib/data-cache'
+
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'https://gp-tracker-hidden-rain-8594.fly.dev/api'
 
-const NO_CACHE = { cache: 'no-store' } as RequestInit
-
+// Public GP data changes only when tournament results or metadata are updated.
+// Cache each API URL in Next's Data Cache, then invalidate the shared tag after
+// a results deployment or admin edit. The one-day TTL is a safety net in case
+// an invalidation webhook is ever missed.
 export interface Tournament {
   id: string
   name: string
@@ -116,7 +120,7 @@ export async function getTournaments(
   if (params.page) searchParams.set('page', params.page.toString())
   if (params.season) searchParams.set('season', params.season.toString())
 
-  const response = await fetch(`${API_BASE}/tournaments?${searchParams}`, NO_CACHE)
+  const response = await fetch(`${API_BASE}/tournaments?${searchParams}`, GP_DATA_CACHE)
   if (!response.ok) throw new Error('Failed to fetch tournaments')
   return response.json()
 }
@@ -126,7 +130,7 @@ export interface SeasonsResponse {
 }
 
 export async function getSeasons(): Promise<SeasonsResponse> {
-  const response = await fetch(`${API_BASE}/seasons`, NO_CACHE)
+  const response = await fetch(`${API_BASE}/seasons`, GP_DATA_CACHE)
   if (!response.ok) throw new Error('Failed to fetch seasons')
   return response.json()
 }
@@ -144,7 +148,7 @@ export async function getTournamentDetails(
   if (params.dir) searchParams.set('dir', params.dir)
   if (params.page) searchParams.set('page', params.page.toString())
 
-  const response = await fetch(`${API_BASE}/tournament/${id}?${searchParams}`, NO_CACHE)
+  const response = await fetch(`${API_BASE}/tournament/${id}?${searchParams}`, GP_DATA_CACHE)
   if (!response.ok) throw new Error('Failed to fetch tournament details')
   return response.json()
 }
@@ -174,7 +178,7 @@ export async function getRankings({
   if (gender) {
     url += `&gender=${gender}`
   }
-  const res = await fetch(url, NO_CACHE)
+  const res = await fetch(url, GP_DATA_CACHE)
   const data = await res.json()
   return data as RankingsResponse
 }
@@ -185,7 +189,7 @@ export async function getPlayer(id: string, params: { season?: number; gender?: 
   if (params.gender) searchParams.set('gender', params.gender)
   const queryString = searchParams.toString()
   const url = queryString ? `${API_BASE}/player/${id}?${queryString}` : `${API_BASE}/player/${id}`
-  const res = await fetch(url, NO_CACHE)
+  const res = await fetch(url, GP_DATA_CACHE)
   const data = await res.json()
   return data as PlayerDetails
 }
@@ -203,7 +207,7 @@ export async function getTournament(
   if (params.dir) searchParams.set('dir', params.dir)
   if (params.page) searchParams.set('page', params.page.toString())
 
-  const res = await fetch(`${API_BASE}/tournament/${id}?${searchParams}`, NO_CACHE)
+  const res = await fetch(`${API_BASE}/tournament/${id}?${searchParams}`, GP_DATA_CACHE)
   const data = await res.json()
   return data as TournamentDetails
 }
@@ -255,13 +259,13 @@ export interface InsightsResponse {
 }
 
 export async function getInsights(season: number): Promise<InsightsResponse> {
-  const res = await fetch(`${API_BASE}/${season}/insights`, NO_CACHE)
+  const res = await fetch(`${API_BASE}/${season}/insights`, GP_DATA_CACHE)
   if (!res.ok) throw new Error('Failed to fetch insights')
   return res.json()
 }
 
 export async function getTournamentAllResults(id: string): Promise<TournamentResult[]> {
-  const res = await fetch(`${API_BASE}/tournament/${id}?all_results=true`, NO_CACHE)
+  const res = await fetch(`${API_BASE}/tournament/${id}?all_results=true`, GP_DATA_CACHE)
   const data = await res.json()
   return data.results as TournamentResult[]
 }

--- a/scripts/test_cache_behavior.py
+++ b/scripts/test_cache_behavior.py
@@ -14,12 +14,19 @@ def test_frontend_revalidation_uses_bearer_secret(monkeypatch):
     captured = {}
 
     class SuccessfulResponse:
+        is_redirect = False
+
         @staticmethod
         def raise_for_status():
             return None
 
-    def fake_post(url, *, headers, timeout):
-        captured.update(url=url, headers=headers, timeout=timeout)
+    def fake_post(url, *, headers, timeout, allow_redirects):
+        captured.update(
+            url=url,
+            headers=headers,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+        )
         return SuccessfulResponse()
 
     monkeypatch.setattr(app_module, "REVALIDATE_SECRET", "test-secret")
@@ -35,7 +42,26 @@ def test_frontend_revalidation_uses_bearer_secret(monkeypatch):
         "url": "https://example.test/api/revalidate",
         "headers": {"Authorization": "Bearer test-secret"},
         "timeout": 5,
+        "allow_redirects": False,
     }
+
+
+def test_frontend_revalidation_uses_canonical_default():
+    assert app_module.FRONTEND_REVALIDATE_URL == "https://www.1700chess.sh/api/revalidate"
+
+
+def test_frontend_revalidation_rejects_redirects(monkeypatch):
+    class RedirectResponse:
+        is_redirect = True
+        headers = {"Location": "https://unexpected.example/api/revalidate"}
+
+    def fake_post(*args, **kwargs):
+        return RedirectResponse()
+
+    monkeypatch.setattr(app_module, "REVALIDATE_SECRET", "test-secret")
+    monkeypatch.setattr(app_module.http_requests, "post", fake_post)
+
+    assert app_module._revalidate_frontend_data() is False
 
 
 def test_frontend_revalidation_is_disabled_without_secret(monkeypatch):

--- a/scripts/test_cache_behavior.py
+++ b/scripts/test_cache_behavior.py
@@ -1,0 +1,44 @@
+import app as app_module
+
+
+def test_public_api_requires_http_revalidation(monkeypatch):
+    monkeypatch.setitem(app_module.app.config, "DEBUG", False)
+
+    response = app_module.app.test_client().get("/api/seasons")
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-cache, must-revalidate"
+
+
+def test_frontend_revalidation_uses_bearer_secret(monkeypatch):
+    captured = {}
+
+    class SuccessfulResponse:
+        @staticmethod
+        def raise_for_status():
+            return None
+
+    def fake_post(url, *, headers, timeout):
+        captured.update(url=url, headers=headers, timeout=timeout)
+        return SuccessfulResponse()
+
+    monkeypatch.setattr(app_module, "REVALIDATE_SECRET", "test-secret")
+    monkeypatch.setattr(
+        app_module,
+        "FRONTEND_REVALIDATE_URL",
+        "https://example.test/api/revalidate",
+    )
+    monkeypatch.setattr(app_module.http_requests, "post", fake_post)
+
+    assert app_module._revalidate_frontend_data() is True
+    assert captured == {
+        "url": "https://example.test/api/revalidate",
+        "headers": {"Authorization": "Bearer test-secret"},
+        "timeout": 5,
+    }
+
+
+def test_frontend_revalidation_is_disabled_without_secret(monkeypatch):
+    monkeypatch.setattr(app_module, "REVALIDATE_SECRET", "")
+
+    assert app_module._revalidate_frontend_data() is False


### PR DESCRIPTION
## Summary

- cache public Flask API fetches in Next's Data Cache under a shared `gp-data` tag
- keep HTML request-rendered with `revalidate = 0` while allowing explicit data caching
- add a protected Next route for immediate tag expiration
- invalidate cached results after Fly deployments and production admin mutations
- make Next the single cache owner by requiring origin HTTP revalidation
- use the canonical `www.1700chess.sh` host and fail closed on redirects

## Why

Tournament data changes only a few times per month. The previous setup forced a fresh Fly request for every render while Flask independently advertised a non-purgeable 24-hour browser/intermediary cache. This change provides fast cached reads with explicit invalidation whenever results change and a one-day safety TTL if a webhook is missed.

## Configuration

Set the same strong `REVALIDATE_SECRET` in Vercel, GitHub Actions, and Fly. Fly may optionally override `FRONTEND_REVALIDATE_URL`.

## Validation

- `19 passed` with pytest
- `bash -n start.sh`
- GitHub Actions workflow parses as YAML
- ESLint: 0 errors; 1 pre-existing hook warning
- new cache/revalidation TypeScript introduces no diagnostics; the repository's existing unrelated TypeScript diagnostics remain
