### PR TITLE
Prevent silent stale-cache deployments

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -12,7 +12,21 @@ jobs:
     concurrency: deploy-group    # optional: ensure only one action runs at a time
     steps:
       - uses: actions/checkout@v4
+      - name: Verify cache revalidation is configured
+        env:
+          REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
+        run: |
+          if [ -z "${REVALIDATE_SECRET}" ]; then
+            echo "::error::REVALIDATE_SECRET is not configured. Refusing to deploy data that the frontend cannot revalidate."
+            exit 1
+          fi
+
       - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Sync cache revalidation secret to Fly
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
+        run: flyctl secrets set --stage REVALIDATE_SECRET="${REVALIDATE_SECRET}"
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
@@ -20,11 +34,6 @@ jobs:
         env:
           REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
         run: |
-          if [ -z "${REVALIDATE_SECRET}" ]; then
-            echo "REVALIDATE_SECRET is not configured; skipping frontend revalidation."
-            exit 0
-          fi
-
           curl --silent --show-error --fail-with-body \
             --location \
             --max-redirs 0 \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,24 @@ When a Grand Prix event is finished, update it in this order:
    - Once an event is scraped and saved as completed, remove it from `upcomingTournaments`.
    - If an event is postponed or not completed, update/move its static record instead of removing it.
 
+6. Deploy and verify cache revalidation.
+   - A successful Fly deployment does not by itself refresh the frontend. Public API fetches use the Next.js Data Cache with the `gp-data` tag.
+   - The Fly workflow must successfully call `https://www.1700chess.sh/api/revalidate` after deploying data.
+   - Verify the public site, tournament detail, Open rankings, and Ladies rankings after deployment. Do not treat a correct Fly API response as sufficient proof that the frontend is fresh.
+
+## Production Cache Revalidation
+
+- `REVALIDATE_SECRET` must use the same strong value in GitHub Actions and the production Vercel project. The deployment workflow synchronizes that value to Fly for admin-triggered invalidation.
+- Never print, log, commit, or expose the secret while testing. Load it from the relevant secret store or a protected temporary file and remove temporary files afterward.
+- The canonical endpoint is `https://www.1700chess.sh/api/revalidate`. Do not use a host that redirects to `www`: HTTP clients may drop the `Authorization` header across a host redirect, and a redirect can otherwise look like a successful invalidation.
+- Missing revalidation configuration is a deployment failure. Never silently skip invalidation and report success.
+- Expected endpoint behavior:
+  - An unauthenticated `POST` returns `401`. A `503` means Vercel does not have `REVALIDATE_SECRET` in that deployment.
+  - An authenticated `POST` returns JSON containing `{"revalidated":true,"tag":"gp-data"}`.
+- After revalidation, use a cache-busting query string when checking rendered production pages. Confirm that the new tournament appears, completed/upcoming counts are correct, and both ranking categories include the expected players.
+- If the Fly API has new data but rendered pages do not, suspect the Next.js tagged Data Cache first. If static upcoming data changed but completed results did not, that is especially strong evidence that the frontend build deployed while the data cache remained stale.
+- When adding or rotating this secret, redeploy Vercel so the route receives the new environment value. Also update GitHub Actions; the next Fly deployment will stage the same value on Fly.
+
 ## Sataranji Context
 
 As of April 20, 2026:
@@ -59,6 +77,7 @@ As of April 20, 2026:
   - `scripts/scrape_2026_tournaments.py`
   - `scripts/backfill_ladies_2025.py`
 - The admin scrape path in `app.py` is the more reliable source of truth for the current workflow.
+- A production database update can be correct while the public site remains stale. Compare the direct Fly API with cache-busted rendered pages and confirm that the revalidation workflow did not skip or redirect.
 
 ## Quick Checks
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,11 @@ site-code deployments are not held behind the data cache.
 Set the same strong `REVALIDATE_SECRET` value in:
 
 - Vercel, for the protected `/api/revalidate` route.
-- GitHub Actions, so a successful Fly deployment invalidates cached results.
-- Fly, so production admin edits can invalidate cached results immediately.
+- GitHub Actions, so deployments invalidate cached results. The workflow also
+  synchronizes this value to Fly so production admin edits invalidate the cache.
+
+The Fly deployment workflow fails before deploying when its GitHub Actions
+secret is missing, rather than publishing new data with a stale frontend cache.
 
 Fly can optionally set `FRONTEND_REVALIDATE_URL` when the frontend revalidation
 endpoint is not `https://www.1700chess.sh/api/revalidate`. If a webhook is missed,


### PR DESCRIPTION
## What changed

- fail the Fly workflow before deployment when `REVALIDATE_SECRET` is missing
- sync the GitHub Actions secret into Fly before each deployment
- keep the authenticated post-deploy frontend invalidation mandatory
- document the deployment behavior in `README.md`
- add the complete production cache-revalidation runbook and failure diagnosis to `AGENTS.md`

## Why

The Kitale backend/database deployment succeeded, but GitHub Actions silently skipped cache invalidation because `REVALIDATE_SECRET` was absent. Vercel then continued serving the old tagged data cache even though the Fly API had the new tournament and rankings.

This makes that configuration failure visible and prevents new backend data from being deployed while the frontend cannot be refreshed. Syncing the value into Fly also keeps admin-triggered invalidation working without separate secret drift.

## Production recovery

The same rotated secret is now configured in GitHub Actions and the production Vercel project. The production cache was invalidated successfully and the public site now shows Kitale, 10 completed events, and refreshed Open/Ladies rankings.

## Checks

- workflow YAML parses successfully
- `git diff --check`
- Python source compilation with a writable bytecode cache
- `scripts/test_cache_behavior.py`
- authenticated production revalidation returned `{revalidated: true, tag: gp-data}`
- verified public homepage, Kitale detail page, Open rankings, and Ladies rankings